### PR TITLE
Update audio_source.cpp

### DIFF
--- a/esphome/components/audio_source/audio_source.cpp
+++ b/esphome/components/audio_source/audio_source.cpp
@@ -19,7 +19,7 @@ void AudioSource::add_audio_callback(std::function<void(AudioStream * )> &&callb
 
 std::string AudioSource::unique_id() { return ""; }
 
-int AudioStream::get_sample_count() {
+int32_t AudioStream::get_sample_count() {
   return audio_buffer_size / (channels * (bits_per_sample /8));
 }
 


### PR DESCRIPTION
Changed definition of AudioStream::get_sample to INT32_T to allow compile on ESP32_C3 that defines INT as INT16_T.

# What does this implement/fix?

Fixes compilation on platforms where INT is not defined as INT32_T, now matches declaration.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:

```yaml
audio_source:
  - platform: i2s_audio_source
    id: i2s_mic
    name: "i2s_mic"
    i2s_lrclk_pin: GPIO0
    i2s_din_pin: GPIO10
    i2s_bclk_pin: GPIO1
    bits_per_sample: 16
    audio_frequency: 16000
    mode: mono

sensor:
  - platform: decibel_meter
    sensitivity: -23
    audio_source: i2s_mic
    name: decibels
```

## Checklist:
  - [] The code change is tested and works locally.
  - [] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
